### PR TITLE
Drop legacy GitHub Packages publishing

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -4,20 +4,6 @@ on:
   release:
     types: [published]
 jobs:
-  publish-to-github-packages:
-    name: Push to GitHub Packages
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2.3.4
-      - name: Build and push to GitHub Packages
-        uses: docker/build-push-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.github_token }}
-          repository: aspearman/static-website/static-website
-          tag_with_ref: true
   publish-to-github-container-registry:
     name: Push to GitHub Container Registry
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Docker registry has been replaced with a more feature-rich GitHub Container registry. Since we've been publishing to both, I simply removed the job to publish to the legacy registry. I'll remove the GitHub package from this repo as well so there's only one package available to pull. 